### PR TITLE
Use numeric index instead of named parameter for sys.version_info for…

### DIFF
--- a/python/lzs.py
+++ b/python/lzs.py
@@ -35,7 +35,7 @@ import sys
 from collections import defaultdict
 
 
-if sys.version_info.major == 2:
+if sys.version_info[0] == 2:
     byteschr = chr
 else:
     def byteschr(x):


### PR DESCRIPTION
… Python2.6 compatibility

sys.version_info added named parameters in Python 2.7. By using a numeric index instead, the code becomes compatible with Python 2.6 which is the version shipped with CentOS/Red Hat Enterprise Linux 6.